### PR TITLE
fix DeprecationWarning: Buffer() by replacing outdated fs.extra with fd-extra

### DIFF
--- a/components/CopyTree.js
+++ b/components/CopyTree.js
@@ -1,4 +1,4 @@
-const fs = require('fs.extra');
+const fs = require('fs-extra');
 const noflo = require('noflo');
 
 // @runtime noflo-nodejs

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=6"
   },
   "dependencies": {
-    "fs.extra": "~1.3.2",
+    "fs-extra": "^10.0.0",
     "mimetype": "~0.0.8",
     "noflo": "^1.0.0"
   },

--- a/test/Unlink.js
+++ b/test/Unlink.js
@@ -53,7 +53,7 @@ exports['test unlink dir'] = function (test) {
   fs.mkdirSync('test-unlink-dir');
   const [c, ins, out, err] = Array.from(setupComponent());
   err.once('data', (err) => {
-    if (os.platform() === 'win32') {
+    if (os.platform() === 'win32' || os.platform() === 'darwin') {
       test.equal(err.code, 'EPERM');
     } else {
       test.equal(err.code, 'EISDIR');


### PR DESCRIPTION
Tests were broken on MacOS / Node 16:
- fix test with wrong os platform detection
